### PR TITLE
Fix run.sh metrics type typo

### DIFF
--- a/examples/run.sh
+++ b/examples/run.sh
@@ -5,4 +5,4 @@ python -m ragchecker.cli \
     --checker_name=bedrock/meta.llama3-70b-instruct-v1:0 \
     --batch_size_extractor=64 \
     --batch_size_checker=64 \
-    --metrics all
+    --metrics all_metrics


### PR DESCRIPTION
### Description

bash example/run.sh fails with
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ubuntu/RAGChecker/ragchecker/cli.py", line 82, in <module>
    main()
  File "/home/ubuntu/RAGChecker/ragchecker/cli.py", line 75, in main
    evaluator.evaluate(rag_results, metrics=args.metrics, save_path=args.output_path)
  File "/home/ubuntu/RAGChecker/ragchecker/evaluator.py", line 197, in evaluate
    raise ValueError(f"Invalid metric: {metric}.")
```

due to `--metrics all` being invalid in run.sh
```bash
# run.sh
python -m ragchecker.cli \
    --input_path=examples/checking_inputs.json \
    --output_path=examples/checking_outputs.json \
    --extractor_name=bedrock/meta.llama3-70b-instruct-v1:0 \
    --checker_name=bedrock/meta.llama3-70b-instruct-v1:0 \
    --batch_size_extractor=64 \
    --batch_size_checker=64 \
    --metrics all
```

This PR updates the run.sh when a successful run should look like
```
Intel(R) Extension for Scikit-learn* enabled (https://github.com/intel/scikit-learn-intelex)
2024-08-23 07:31:46.979 | INFO     | ragchecker.evaluator:extract_claims:101 - Extracting claims for response of 2 RAG results.
100%|█████| 1/1 [00:04<00:00,  4.16s/it]
2024-08-23 07:31:51.135 | INFO     | ragchecker.evaluator:check_claims:156 - Checking retrieved2response for 2 RAG results.
100%|█████| 1/1 [00:00<00:00,  1.16it/s]
2024-08-23 07:31:51.997 | INFO     | ragchecker.evaluator:extract_claims:101 - Extracting claims for gt_answer of 2 RAG results.
100%|█████| 1/1 [00:06<00:00,  6.59s/it]
2024-08-23 07:31:58.583 | INFO     | ragchecker.evaluator:check_claims:156 - Checking response2answer for 2 RAG results.
100%|█████| 1/1 [00:00<00:00,  1.42it/s]
2024-08-23 07:31:59.289 | INFO     | ragchecker.evaluator:check_claims:156 - Checking answer2response for 2 RAG results.
100%|█████| 1/1 [00:00<00:00,  1.42it/s]
2024-08-23 07:31:59.993 | INFO     | ragchecker.evaluator:check_claims:156 - Checking retrieved2answer for 2 RAG results.
100%|█████| 1/1 [00:01<00:00,  1.27s/it]
{
  "overall_metrics": {
    "precision": 77.5,
    "recall": 64.2,
    "f1": 68.3
  },
  "retriever_metrics": {
    "claim_recall": 59.1,
    "context_precision": 87.5
  },
  "generator_metrics": {
    "context_utilization": 81.2,
    "noise_sensitivity_in_relevant": 4.2,
    "noise_sensitivity_in_irrelevant": 4.2,
    "hallucination": 14.2,
    "self_knowledge": 20.8,
    "faithfulness": 65.0
  }
}
```