### PR TITLE
saves final metrics to path

### DIFF
--- a/ragchecker/evaluator.py
+++ b/ragchecker/evaluator.py
@@ -226,5 +226,10 @@ class RAGChecker():
                     results.metrics[group][metric] = round(np.mean(
                         [result.metrics[metric] for result in results.results]
                     ) * 100, 1)
+        
+        # save the results            
+        if save_path is not None:
+                with open(save_path, "w") as f:
+                    f.write(results.to_json(indent=2))
 
         return results.metrics


### PR DESCRIPTION
*Issue #, if available:*
Once aggregated metrics are computed, they are not saved to the file path.

*Description of changes:*
Once all metrics are computed and aggregated, this saves them to the path if it exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
